### PR TITLE
Fix quotes

### DIFF
--- a/src/Fake.Persimmon/PersimmonHelper.fs
+++ b/src/Fake.Persimmon/PersimmonHelper.fs
@@ -39,13 +39,13 @@ let buildPersimmonArgs parameters assemblies =
     match parameters.Output with
     | OutputDestination.Console -> false, ""
     | PlaneTextFile path -> (true, sprintf "--output:%s" <| path.TrimEnd Path.DirectorySeparatorChar)
-    | XmlFile path -> (true, sprintf "--output:%s --format:xml" <| path.TrimEnd Path.DirectorySeparatorChar)
+    | XmlFile path -> (true, sprintf "\"--output:%s\" --format:xml" <| path.TrimEnd Path.DirectorySeparatorChar)
   let error, errorText =
     match parameters.Error with
     | Console -> false, ""
     | File path -> (true, sprintf "--error:%s" <| path.TrimEnd Path.DirectorySeparatorChar)
   StringBuilder()
-  |> appendIfTrue output outputText
+  |> appendIfTrueWithoutQuotes output outputText
   |> appendIfTrue error errorText
   |> appendIfTrue parameters.NoProgress "--no-progress"
   |> appendIfTrue parameters.Parallel "--parallel"


### PR DESCRIPTION
This PR fixes invalid quotation when the Output parameter is OutputDestination.XmlFile.

The Output parameter with XmlFile should handled as two arguments (--output and --format) passed to the console program.
But, because FAKE's `appendIfTrue` function quotes the argument string, both --output and --format are quoted as one argument.
If I pass XmlFile("TestResults.xml"), then the argument becomes "--output:TestResults.xml --format:xml" and the output file is "TestResults.xml --format:xml".
This is an invalid file name so that the FAKE script fails when the `Persimmon` job is invoked.

Instead calling `appendIfTrue`, I use `appendIfTrueWithoutQuotes` and quote the --output argument explicitly to resolve the problem.
